### PR TITLE
Skipping launcher with -nolauncher launch flag

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using NLog.Config;
 using NLog.Targets;
 using System.Diagnostics;
 using System.Globalization;
+using System.Media;
 using System.Runtime.InteropServices;
 
 namespace CityLauncher
@@ -34,12 +35,18 @@ namespace CityLauncher
         ///     @author Neato (https://steamcommunity.com/id/frofoo)
         /// </summary>
         [STAThread]
-        static void Main()
+        static void Main(string[] args)
         {
             bool IsNewWindow = true;
             using (Mutex mtx = new(true, "{BD4C408D-EF15-4C98-B792-C30D089E19D1}", out IsNewWindow))
             {
-                if (IsNewWindow)
+                if (args.Contains("-nolauncher"))
+                {
+                    SetupCulture();
+                    SetupLogger();
+                    LauncherBypass();
+                }
+                else if (IsNewWindow)
                 {
                     SetupCulture();
                     SetupLogger();
@@ -108,5 +115,25 @@ namespace CityLauncher
             config.AddRule(LogLevel.Debug, LogLevel.Warn, logfile);
             LogManager.Configuration = config;
         }
-    }
+
+        private static void LauncherBypass()
+        {
+            Nlog.Info("LauncherBypass - Starting logs at {0} on {1}.", DateTime.Now.ToString("HH:mm:ss"), DateTime.Now.ToString("D", new CultureInfo("en-GB")));
+            using (Process LaunchGame = new())
+            {
+                if (FileHandler.DetectGameExe())
+                {
+                    LaunchGame.StartInfo.FileName = "BatmanAC.exe";
+                    LaunchGame.StartInfo.CreateNoWindow = true;
+                    LaunchGame.Start();
+                    Nlog.Info("LauncherBypass - Launching the game. Concluding logs at {0} on {1}.", DateTime.Now.ToString("HH:mm:ss"), DateTime.Now.ToString("D", new CultureInfo("en-GB")));
+                    Application.Exit();
+                }
+                else
+                {
+                    MessageBox.Show("Could not find 'BatmanAC.exe'.\nIs the Launcher in the correct folder?", "Error!", MessageBoxButtons.OK);
+                }
+            }
+        }
+}
 }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a replacement application for the original BmLauncher.exe of the game. A
 - Color settings (Including color palette presets)
 - Two pre-made color profiles for HDR injection
 - Keybind option for [Catwoman's "Quickfire Disarm"](https://www.pcgamingwiki.com/wiki/Batman:_Arkham_City#Fix_for_Catwoman.27s_Quickfire_Disarm_key_missing_on_keyboard)
+- Option to boot directly into the game, skipping launcher screen
 - Automatic DirectX11 Lighting Bug Fix (No actions needed. It happens in the background!)
 - Customizable Field of View Hotkeys
 - Compatibility Fixes for [HD Texture Packs](https://steamcommunity.com/sharedfiles/filedetails/?id=1188257825)
@@ -41,6 +42,18 @@ To find this folder for the *Steam* version, just right-click the game in Steam,
 To find it for the *EGS* version, right-click the game and select "Manage". Then click the folder icon in the "Installation" tab and navigate from there.
 
 For the *GOG* version, click the icon next to the PLAY button and select "Manage installation->Show folder" and navigate from there.
+
+## Usage
+
+You can just launch your game via Steam or EGS as you normally would, though in some cases you might need to unblock the BmLauncher application for it to work properly.
+
+Once you're happy with your settings, you can skip the launcher entirely by using the `-nolauncher` launch option.
+
+- On *EGS* you can add this under Settings->Arkham Asylum->Additional Command Line Arguments. 
+- On *GOG GALAXY* Customize->Manage Installation->Configure, enable Launch parameters, select Duplicate. It should be added under Additional executables.
+- If you use a shortcut in Windows, right click->Properties->Shortcut and add it at the end of Target.
+- Not necessary for *Steam*, which already has built-in launcher skipping for this game. 
+
 
 ## Guide for Linux users
 


### PR DESCRIPTION
I already made this for the [Arkham Asylum launcher](https://github.com/neatodev/BmLauncherAsylumNET6/pull/14), so might as well add it here too.

Program.cs now checks launch flags for -nolauncher parameter. If present, the game starts with unchanged settings, without showing the launcher.